### PR TITLE
monitor: fix command search in el7

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -109,6 +109,7 @@ func init() {
 
 	// monitor command flags
 	startCmd.PersistentFlags().String("cmd-ifconfig", "/usr/bin/ifconfig", "The path of 'ifconfig'")
+	startCmd.PersistentFlags().String("cmd-ifconfig2", "/usr/sbin/ifconfig", "The path of 'ifconfig'")
 	startCmd.PersistentFlags().String("cmd-ifconfig-arg", "", "Parameters when executing 'ifconfig'")
 	startCmd.PersistentFlags().String("cmd-ss", "/usr/bin/ss", "The path of 'ss'")
 	startCmd.PersistentFlags().String("cmd-ss2", "/usr/sbin/ss", "The path of 'ss'")

--- a/tcpmon/cmd_test.go
+++ b/tcpmon/cmd_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/zperf/tcpmon/tcpmon"
 )
 
 type CommandParserTestSuite struct {
@@ -12,4 +14,9 @@ type CommandParserTestSuite struct {
 
 func TestCommandParser(t *testing.T) {
 	suite.Run(t, new(CommandParserTestSuite))
+}
+
+func (s *CommandParserTestSuite) TestFileFallback() {
+	f := tcpmon.FileFallback("abc", "foo", "/bin/bash")
+	s.Assert().Equal("/bin/bash", f)
 }


### PR DESCRIPTION
At CentOS 7, ss and ifconfig are placed at /usr/sbin