### PR TITLE
cmd: fix config and flags loading process

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,10 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
-	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -33,19 +30,4 @@ var configGetDefaultCmd = &cobra.Command{
 func init() {
 	configCmd.AddCommand(configGetDefaultCmd)
 	rootCmd.AddCommand(configCmd)
-}
-
-func writeDefaultConfig() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	parentDir := filepath.Join(home, ".tcpmon")
-	err = os.MkdirAll(parentDir, 0755)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	return errors.WithStack(viper.SafeWriteConfigAs(filepath.Join(parentDir, "config.yaml")))
 }

--- a/cmd/op.go
+++ b/cmd/op.go
@@ -56,9 +56,7 @@ var opBackupAllCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(opCmd)
-
 	opBackupAllCmd.Flags().DurationP("timeout", "t", 4*time.Second, "HTTP timeout")
+	rootCmd.AddCommand(opCmd)
 	opCmd.AddCommand(opBackupAllCmd)
-	fatalIf(viper.BindPFlags(opBackupAllCmd.Flags()))
 }

--- a/rpm/tcpmon.yaml
+++ b/rpm/tcpmon.yaml
@@ -13,7 +13,6 @@ db-expected-rss: "209715200"
 db-max-size: "2000000"
 db-min-open-interval: 1m0s
 db-write-interval: 3s
-disable-console: true
 listen: 0.0.0.0:6789
 log-dir: /var/log/tcpmon
 log-filename: tcpmon.log

--- a/tcpmon/logger.go
+++ b/tcpmon/logger.go
@@ -97,7 +97,7 @@ type BadgerDbLogger struct {
 
 func NewBadgerLogger() *BadgerDbLogger {
 	return &BadgerDbLogger{
-		log: log.With().Str("mod", "badger").Logger().Level(zerolog.InfoLevel),
+		log: log.With().Str("mod", "badger").Logger(),
 	}
 }
 
@@ -123,7 +123,7 @@ type MemberlistLogger struct {
 
 func NewMemberlistLogger() *MemberlistLogger {
 	return &MemberlistLogger{
-		log: log.With().Str("mod", "memberlist").Logger().Level(zerolog.InfoLevel),
+		log: log.With().Str("mod", "memberlist").Logger(),
 	}
 }
 


### PR DESCRIPTION
Get value from viper, like `viper.GetString()`

Value priority:

1. Return value from config file
2. Return value from flag value, passed by command line
3. Return value from flag default value