### PR TITLE
storage: trim seal file suffix when get last file seq

### DIFF
--- a/tcpmon/storage/v2/storage.go
+++ b/tcpmon/storage/v2/storage.go
@@ -152,6 +152,10 @@ func (ds *DataStore) GetLatestFileNo() uint32 {
 		return 0
 	}
 
+	fileNames = lo.Map(fileNames, func(f string, i int) string {
+		return strings.TrimSuffix(f, SealFileSuffix)
+	})
+
 	sort.Strings(fileNames)
 	lastFile := fileNames[len(fileNames)-1]
 

--- a/test/storage_v2_test.go
+++ b/test/storage_v2_test.go
@@ -85,6 +85,25 @@ func (suite *StorageV2TestSuite) TestRotateFile() {
 	suite.Require().Equal(toWrite, count)
 }
 
+func (suite *StorageV2TestSuite) TestGetLastFileNo() {
+	_, err := suite.fs.Create("tcpmon-dataf-1")
+	suite.Require().NoError(err)
+	_, err = suite.fs.Create("tcpmon-dataf-1.zst")
+	suite.Require().NoError(err)
+
+	cfg := v2.NewConfig(suite.baseDir).
+		WithFs(suite.fs).
+		WithMaxSize(10 * (1 << 20)).
+		WithMaxEntriesPerFile(3)
+
+	ds, err := v2.NewDataStore(cfg)
+	suite.Require().NoError(err)
+	defer ds.Close()
+
+	last := ds.GetLatestFileNo()
+	suite.Require().Equal(uint32(1), last)
+}
+
 func randBuf(size int) []byte {
 	buf := make([]byte, size)
 	_, err := rand.Read(buf)


### PR DESCRIPTION
`GetLatestFileNo()` does not work properly when there is a `.zst` file in the data directory.

```
-rw-r--r--   1 root root 1.7G Sep 18 20:02 tcpmon-dataf-1
-rw-r--r--   1 root root 133M Sep 18 20:02 tcpmon-dataf-1.zst
```